### PR TITLE
Feature/fs02-45/componente organization creado y obtencionn del futuro componente edicion del formulario

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import ToysCampaign from './Campaigns/Toys/ToysCampaign';
 import MembersForm from './Components/Members/MembersForm';
 import ProjectsForm from './Components/Projects/ProjectsForm';
 import About from './about/About';
+import Organization from './Components/Organization/Organization';
 
 function App() {
   return (
@@ -32,6 +33,7 @@ function App() {
           <Route path="/school-campaign" component={SchoolCampaign} />
           <Route path="/toys-campaign" component={ToysCampaign} />
           <Route path="/about" component={About} />
+          <Route path="/backoffice/organization" component={Organization} />
         </Switch>
       </BrowserRouter>
     </>

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,6 @@ function App() {
           <Route path="/toys-campaign" component={ToysCampaign} />
           <Route path="/about" component={About} />
           <Route path="/backoffice/organization" component={Organization} />
-          <Route path="/backoffice/organization/edit" component={Organization} />
         </Switch>
       </BrowserRouter>
     </>

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,8 @@ import MembersForm from './Components/Members/MembersForm';
 import ProjectsForm from './Components/Projects/ProjectsForm';
 import About from './about/About';
 import Organization from './Components/Organization/Organization';
+import orga from './Components/Organization/formularioEdicion';
+
 
 function App() {
   return (
@@ -34,6 +36,7 @@ function App() {
           <Route path="/toys-campaign" component={ToysCampaign} />
           <Route path="/about" component={About} />
           <Route path="/backoffice/organization" component={Organization} />
+          <Route path="/backoffice/organization/edit" component={Organization} />
         </Switch>
       </BrowserRouter>
     </>

--- a/src/App.js
+++ b/src/App.js
@@ -15,8 +15,6 @@ import MembersForm from './Components/Members/MembersForm';
 import ProjectsForm from './Components/Projects/ProjectsForm';
 import About from './about/About';
 import Organization from './Components/Organization/Organization';
-import orga from './Components/Organization/formularioEdicion';
-
 
 function App() {
   return (

--- a/src/Components/Organization/Organization.css
+++ b/src/Components/Organization/Organization.css
@@ -1,0 +1,7 @@
+.organization-container {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+
+    width: 100vw;
+}

--- a/src/Components/Organization/Organization.css
+++ b/src/Components/Organization/Organization.css
@@ -4,4 +4,29 @@
     flex-direction: column;
 
     width: 100vw;
+    margin-top: 2rem;
+}
+
+.organization-container__div {
+    display: flex;
+    width: 75%;
+    justify-content: space-around;
+    align-items: center;
+}
+
+.organization-container__p {
+    width: 75%;
+    font-size: 1.5rem;
+    margin: 0 2rem;
+    font-family: 'Montserrat';
+    font-weight: bold;
+}
+
+.organization-container__div-img {
+    width : 30%;
+}
+
+.organization-container__button{
+    margin: 5rem auto;
+    width: 80%;
 }

--- a/src/Components/Organization/Organization.js
+++ b/src/Components/Organization/Organization.js
@@ -2,19 +2,28 @@
 Al ingresar a la ruta /backoffice/organization se mostrarán los datos actuales de la Organización 
 (name, image, shortDescription), y la acción para acceder al formulario de edición (/backoffice/organization/edit)*/
 import { useEffect, useState } from 'react';
+import { useHistory,Link } from 'react-router-dom';
 import { Get } from '../../Services/privateApiService';
 import './Organization.css';
 import '../../general-styles.css';
 
 const Organization = () => { 
+    const history = useHistory();
     const [information, setInformation] = useState({});
+    const [showEditForm, setShowEditForm] = useState(false);
+
+    function handleClick (e) {
+        e.preventDefault();
+        setShowEditForm(!showEditForm);
+        console.log(showEditForm);
+        history.push('/backoffice/organization/edit/');
+    }
 
     const getData = async () => {
         try {
             let res = await Get('/organization');
             setInformation(res.data.data)
         } catch (err) {
-            alert('Hubo un error')
             return err;
         }
     }
@@ -23,16 +32,20 @@ const Organization = () => {
         getData()
     } , []);
 
-
     return (
+        <>
         <div className='organization-container' >
             <div className='organization-container__div'>
-                <img className='organization-container__div-img' src={information.logo} alt='imagen ong' />
+                <img className='organization-container__div-img' src={information.logo} alt='imagen ong'/>
                 <h1 className='title'>{information.name}</h1>
             </div>
             <div className='organization-container__p' dangerouslySetInnerHTML={{__html: information.short_description}} />
-            <button className='primary-backoffice-button organization-container__button'>Editar</button>
-        </div>
+            <button className='primary-backoffice-button organization-container__button' onClick={handleClick}>
+                Editar
+            </button>
+        </div>  
+        {(showEditForm)? <p> Aca se debería mostrar el formulario de edicion</p> : <></>}
+        </>    
     )
 }
 

--- a/src/Components/Organization/Organization.js
+++ b/src/Components/Organization/Organization.js
@@ -1,10 +1,34 @@
 /*
 Al ingresar a la ruta /backoffice/organization se mostrarán los datos actuales de la Organización 
 (name, image, shortDescription), y la acción para acceder al formulario de edición (/backoffice/organization/edit)*/
+import { useEffect, useState } from 'react';
+import { Get } from '../../Services/privateApiService';
+import './Organization.css';
 
-const Organization = () => {
+const Organization = () => { 
+    const [information, setInformation] = useState({});
+
+    const getData = async () => {
+        try {
+            let res = await Get('/organization');
+            setInformation(res.data.data)
+        } catch (err) {
+            alert('Hubo un error')
+            return err;
+        }
+    }
+    
+    useEffect(() => {
+        getData()
+    } , []);
+
+
     return (
-        <h1>Organizacion</h1>
+        <div className="organization-container">
+            <h1>{information.name}</h1>
+            <img src={information.logo} alt='imagen ong' />
+            <p>{information.short_description}</p>
+        </div>
     )
 }
 

--- a/src/Components/Organization/Organization.js
+++ b/src/Components/Organization/Organization.js
@@ -4,6 +4,7 @@ Al ingresar a la ruta /backoffice/organization se mostrarán los datos actuales 
 import { useEffect, useState } from 'react';
 import { Get } from '../../Services/privateApiService';
 import './Organization.css';
+import '../../general-styles.css';
 
 const Organization = () => { 
     const [information, setInformation] = useState({});
@@ -24,10 +25,13 @@ const Organization = () => {
 
 
     return (
-        <div className="organization-container">
-            <h1>{information.name}</h1>
-            <img src={information.logo} alt='imagen ong' />
-            <p>{information.short_description}</p>
+        <div className='organization-container' >
+            <div className='organization-container__div'>
+                <img className='organization-container__div-img' src={information.logo} alt='imagen ong' />
+                <h1 className='title'>{information.name}</h1>
+            </div>
+            <div className='organization-container__p' dangerouslySetInnerHTML={{__html: information.short_description}} />
+            <button className='primary-backoffice-button organization-container__button'>Editar</button>
         </div>
     )
 }

--- a/src/Components/Organization/Organization.js
+++ b/src/Components/Organization/Organization.js
@@ -15,7 +15,6 @@ const Organization = () => {
     function handleClick (e) {
         e.preventDefault();
         setShowEditForm(!showEditForm);
-        console.log(showEditForm);
         history.push('/backoffice/organization/edit/');
     }
 
@@ -34,17 +33,23 @@ const Organization = () => {
 
     return (
         <>
-        <div className='organization-container' >
-            <div className='organization-container__div'>
-                <img className='organization-container__div-img' src={information.logo} alt='imagen ong'/>
-                <h1 className='title'>{information.name}</h1>
-            </div>
-            <div className='organization-container__p' dangerouslySetInnerHTML={{__html: information.short_description}} />
-            <button className='primary-backoffice-button organization-container__button' onClick={handleClick}>
-                Editar
-            </button>
-        </div>  
-        {(showEditForm)? <p> Aca se debería mostrar el formulario de edicion</p> : <></>}
+        { (!showEditForm)? 
+            <div className='organization-container' >
+                <div className='organization-container__div'>
+                    <img className='organization-container__div-img' src={information.logo} alt='imagen ong'/>
+                    <h1 className='title'>{information.name}</h1>
+                </div>
+                <div className='organization-container__p' dangerouslySetInnerHTML={{__html: information.short_description}} />
+                <button className='primary-backoffice-button organization-container__button' onClick={handleClick}>
+                    Editar
+                </button>
+            </div>  
+            :
+            <>
+            <p> Aca se debería mostrar el formulario de edicion</p> 
+            <button type='submit' onClick={handleClick}>Submit</button>
+            </>
+            }
         </>    
     )
 }

--- a/src/Components/Organization/Organization.js
+++ b/src/Components/Organization/Organization.js
@@ -1,0 +1,11 @@
+/*
+Al ingresar a la ruta /backoffice/organization se mostrarán los datos actuales de la Organización 
+(name, image, shortDescription), y la acción para acceder al formulario de edición (/backoffice/organization/edit)*/
+
+const Organization = () => {
+    return (
+        <h1>Organizacion</h1>
+    )
+}
+
+export default Organization;

--- a/src/Components/Organization/Organization.js
+++ b/src/Components/Organization/Organization.js
@@ -12,7 +12,7 @@ const Organization = () => {
     const [information, setInformation] = useState({});
     const [showEditForm, setShowEditForm] = useState(false);
 
-    function handleClick (e) {
+    const handleClick = (e) => {
         e.preventDefault();
         setShowEditForm(!showEditForm);
         history.push('/backoffice/organization/edit/');


### PR DESCRIPTION
Componente organization creado. Este mismo también viaja a la ruta backoffice/organization/edit y se mostraría el formulario de edición cuando sea creado.

Tengo dos consultas respceto a esto. Una es cuando se muestra el formulario, también se deben mantener la estructura del componente anterior (en este caso organization) y si yo debería crear el HTML formulario (esto último entiendo que no porque la tarjeta no lo dice)

Actualmente el componente organization lo que hace es mostrar los datos de la ONG y si clickea en el botón editar se agregaría al componente el formulario de edición, pero este componente sigue mostrando los datos mencionados anteriormente.

![organization](https://user-images.githubusercontent.com/50428678/168167737-3fdefee0-ed7b-4e96-bfc8-8b841be4dc69.png)

UNA VEZ QU ESE DA CLICK EN EDITAR, SE MOSTRARÍA EL FORMULARIO

![formluario edicion](https://user-images.githubusercontent.com/50428678/168167733-0b3bd5a5-0be6-4420-973b-6fb6699187fc.png)


 