### PR TITLE
Feature/fs02_122/Protección contacto de usuario Admin

### DIFF
--- a/src/Components/Frontoffice/Contact/Contact.js
+++ b/src/Components/Frontoffice/Contact/Contact.js
@@ -1,13 +1,30 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
+import React, { useEffect } from 'react'
+import { Link, useHistory } from 'react-router-dom'
 import './Contact.css'
 import ContactForm from './ContactForm'
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import TwitterIcon from '@mui/icons-material/Twitter';
 import FacebookIcon from '@mui/icons-material/Facebook';
 import InstagramIcon from '@mui/icons-material/Instagram';
+import { getIsAdmin } from '../../Backoffice/RoutesSecurity/RoutesSecurity'
+
 
 const Contact = (props) => {
+
+  const history = useHistory();
+
+  const checkIsAdmin = async () => {
+    const response = await getIsAdmin();
+    return response;
+  }
+
+  
+  useEffect(() => {
+    if(checkIsAdmin()) {
+      history.push("/backoffice/dashboard")
+    }
+  }, [])
+
   const { 
     address, 
     instagram_url, 

--- a/src/Components/Frontoffice/Contact/Contact.js
+++ b/src/Components/Frontoffice/Contact/Contact.js
@@ -13,14 +13,8 @@ const Contact = (props) => {
 
   const history = useHistory();
 
-  const checkIsAdmin = async () => {
-    const response = await getIsAdmin();
-    return response;
-  }
-
-  
   useEffect(() => {
-    if(checkIsAdmin()) {
+    if(getIsAdmin()) {
       history.push("/backoffice/dashboard")
     }
   }, [])

--- a/src/Components/Frontoffice/PublicHeader/PublicHeader.js
+++ b/src/Components/Frontoffice/PublicHeader/PublicHeader.js
@@ -7,16 +7,10 @@ import { useState, useEffect } from 'react'
 
 const PublicHeader = () => {
 
-
-  const checkIsAdmin = async () => {
-    const response = await getIsAdmin();
-    return response;
-  }
-
   const [isAdmin, setIsAdmin] = useState(false);
   
   useEffect(() => {
-    if(checkIsAdmin()) {
+    if(getIsAdmin()) {
       setIsAdmin(true)
     }
   }, [])

--- a/src/Components/Frontoffice/PublicHeader/PublicHeader.js
+++ b/src/Components/Frontoffice/PublicHeader/PublicHeader.js
@@ -2,8 +2,24 @@ import { Link } from 'react-router-dom'
 
 import '../PublicHeader/PublicHeaderStyles.css'
 import getToken from '../../../Services/getToken'
+import { getIsAdmin } from '../../Backoffice/RoutesSecurity/RoutesSecurity'
+import { useState, useEffect } from 'react'
 
 const PublicHeader = () => {
+
+
+  const checkIsAdmin = async () => {
+    const response = await getIsAdmin();
+    return response;
+  }
+
+  const [isAdmin, setIsAdmin] = useState(false);
+  
+  useEffect(() => {
+    if(checkIsAdmin()) {
+      setIsAdmin(true)
+    }
+  }, [])
 
     return (
         <header className="header-container">
@@ -23,7 +39,7 @@ const PublicHeader = () => {
                 <li className='list-container-header__li'><Link to='/about-us' className='link-public-header'>Nosotros</Link></li>
                 <li className='list-container-header__li'><Link to='/news' className='link-public-header'>Novedades</Link></li>
                 <li className='list-container-header__li'><Link to='/testimonials' className='link-public-header'>Testimonios</Link></li>
-                <li className='list-container-header__li'><Link to='/contact' className='link-public-header'>Contacto</Link></li>
+                {isAdmin || <li className='list-container-header__li'><Link to='/contact' className='link-public-header'>Contacto</Link></li>}
                 <li className='list-container-header__li'><Link to='/contributes' className='link-public-header'>Contribuye</Link></li>
              </ul>
            </div>


### PR DESCRIPTION
No se visualizá la opción de contacto en el header si el usuario es admin, y cuando intenta ingresar a la ruta /contact se lo redirige al backoffice/dashboard
![image](https://user-images.githubusercontent.com/105232793/169380597-c075e86e-2180-4b43-981d-dc9b5d2ede45.png)
